### PR TITLE
Minor highlighting change and code formatting fix

### DIFF
--- a/colors/Tomorrow-Night-Blue.vim
+++ b/colors/Tomorrow-Night-Blue.vim
@@ -244,7 +244,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
-    call <SID>X("MoreMsg", s:green, "", "")
+	call <SID>X("MoreMsg", s:green, "", "")
 	call <SID>X("Question", s:green, "", "")
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
@@ -253,7 +253,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
-  if version >= 703
+	if version >= 703
 		call <SID>X("ColorColumn", "", s:line, "none")
 	end
 

--- a/colors/Tomorrow-Night-Bright.vim
+++ b/colors/Tomorrow-Night-Bright.vim
@@ -244,7 +244,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
-    call <SID>X("MoreMsg", s:green, "", "")
+	call <SID>X("MoreMsg", s:green, "", "")
 	call <SID>X("Question", s:green, "", "")
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
@@ -253,7 +253,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
-  if version >= 703
+	if version >= 703
 		call <SID>X("ColorColumn", "", s:line, "none")
 	end
 

--- a/colors/Tomorrow-Night-Eighties.vim
+++ b/colors/Tomorrow-Night-Eighties.vim
@@ -244,7 +244,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
-    call <SID>X("MoreMsg", s:green, "", "")
+	call <SID>X("MoreMsg", s:green, "", "")
 	call <SID>X("Question", s:green, "", "")
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
@@ -253,7 +253,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
-  if version >= 703
+	if version >= 703
 		call <SID>X("ColorColumn", "", s:line, "none")
 	end
 

--- a/colors/Tomorrow-Night.vim
+++ b/colors/Tomorrow-Night.vim
@@ -253,7 +253,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
-    call <SID>X("MoreMsg", s:green, "", "")
+	call <SID>X("MoreMsg", s:green, "", "")
 	call <SID>X("Question", s:green, "", "")
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
@@ -262,7 +262,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
-  if version >= 703
+	if version >= 703
 		call <SID>X("ColorColumn", "", s:line, "none")
 	end
 

--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -243,7 +243,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
-    call <SID>X("MoreMsg", s:green, "", "")
+	call <SID>X("MoreMsg", s:green, "", "")
 	call <SID>X("Question", s:green, "", "")
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
@@ -252,7 +252,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
-  if version >= 703
+	if version >= 703
 		call <SID>X("ColorColumn", "", s:line, "none")
 	end
 


### PR DESCRIPTION
Just a couple of small changes I'm using, and some mixed code indenting fixes.

c0e95308dd46055effac489a6fd172c1c99f0424 may be more controversial [??]. I have darkened the statusline and splits in Tomorrow-Night to make them a bit more subtle while still clearly delineating different windows. Applying similar changes to the other themes gave mixed results, so I have left them out. I can work on them further if you like this change.
