### PR TITLE
Deemphasize line numbers

### DIFF
--- a/colors/Tomorrow-Night.vim
+++ b/colors/Tomorrow-Night.vim
@@ -240,7 +240,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 
 	" Vim Highlighting
 	call <SID>X("Normal", s:foreground, s:background, "")
-	call <SID>X("LineNr", s:foreground, "", "")
+	call <SID>X("LineNr", s:selection, "", "")
 	call <SID>X("NonText", s:selection, "", "")
 	call <SID>X("SpecialKey", s:selection, "", "")
 	call <SID>X("Search", s:background, s:yellow, "")


### PR DESCRIPTION
This might be a tad controversial. I like line numbers to be more of a subdued color than the normal white text. I used the selection color, which you may find too low-contrast, but I quite like it.
