### PR TITLE
Fixes missing s:window and aqua declarations

### DIFF
--- a/colors/Tomorrow-Night-Blue.vim
+++ b/colors/Tomorrow-Night-Blue.vim
@@ -16,6 +16,7 @@ let s:green = "d1f1a9"
 let s:aqua = "99ffff"
 let s:blue = "bbdaff"
 let s:purple = "ebbbff"
+let s:window = "4d5057"
 
 set background=dark
 hi clear

--- a/colors/Tomorrow-Night-Bright.vim
+++ b/colors/Tomorrow-Night-Bright.vim
@@ -16,6 +16,7 @@ let s:green = "b9ca4a"
 let s:aqua = "70c0b1"
 let s:blue = "7aa6da"
 let s:purple = "c397d8"
+let s:window = "4d5057"
 
 set background=dark
 hi clear

--- a/colors/Tomorrow-Night-Eighties.vim
+++ b/colors/Tomorrow-Night-Eighties.vim
@@ -16,6 +16,7 @@ let s:green = "99cc99"
 let s:aqua = "009999"
 let s:blue = "99cccc"
 let s:purple = "cc99cc"
+let s:window = "4d5057"
 
 set background=dark
 hi clear

--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -13,8 +13,10 @@ let s:red = "c82829"
 let s:orange = "f5871f"
 let s:yellow = "eab700"
 let s:green = "718c00"
+let s:aqua = "3e999f"
 let s:blue = "4271ae"
 let s:purple = "8959a8"
+let s:window = "efefef"
 
 set background=light
 hi clear


### PR DESCRIPTION
Adds missing declarations for s:window in the Tomorrow, Tomorrow Night
Bright, Tomorrow Night Blue, and Tomorrow Night Eighites themes. For the
Tomorrow Night Bright and Tomorrow Night Eighties themes, the s:window
value was set to the same value as was set in Tomorrow Night. For the
Tomorrow Night Blue and Tomorrow themes, the current line color as
specified at https://github.com/ChrisKempson/Tomorrow-Theme was used

Also added a missing aqua declaration to the Tomorrow theme. This
was set to the value specified in the above link.
