### PR TITLE
make diff highlighting useful

### DIFF
--- a/colors/Tomorrow-Night.vim
+++ b/colors/Tomorrow-Night.vim
@@ -342,8 +342,14 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting
+  let s:diffbackground = "494e56"
+
 	call <SID>X("diffAdded", s:green, "", "")
 	call <SID>X("diffRemoved", s:red, "", "")
+  call <SID>X("DiffAdd", s:green, s:diffbackground, "")
+  call <SID>X("DiffDelete", s:red, s:diffbackground, "")
+  call <SID>X("DiffChange", s:yellow, s:diffbackground, "")
+  call <SID>X("DiffText", s:diffbackground, s:orange, "")
 
     " ShowMarks Highlighting
     call <SID>X("ShowMarksHLl", s:orange, s:background, "none")


### PR DESCRIPTION
The diff highlighting when using vimdiff or a tool like fugitive (`:Gdiff`) is near unusable.  I'm not suggesting you merge this immediately since I'm using colors outside of the tomorrow theme palette, but I'd like to consider how we can improve diff highlighting.  I've included my changes as an example.
