### PR TITLE
Making statusline of active window stand out more in console vim

### DIFF
--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -240,6 +240,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Search", s:foreground, s:yellow, "")
 	call <SID>X("TabLine", s:foreground, s:background, "reverse")
 	call <SID>X("StatusLine", s:foreground, s:background, "reverse")
+	call <SID>X("WildMenu", s:green, s:background, "reverse")
 	call <SID>X("StatusLineNC", s:window, s:foreground, "reverse")
 	call <SID>X("VertSplit", s:window, s:window, "none")
 	call <SID>X("Visual", "", s:selection, "")


### PR DESCRIPTION
Yellow on gray is a bit difficult to read to begin with, and doesn't make the active window stand out very well. I've changed the statusline of the active window to be white on black here to make it easier to tell where you are.
