### PR TITLE
Improving background color of selected item in wildmenu

### DIFF
--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -241,6 +241,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("TabLine", s:foreground, s:background, "reverse")
 	call <SID>X("StatusLine", s:window, s:yellow, "reverse")
 	call <SID>X("StatusLineNC", s:window, s:foreground, "reverse")
+	call <SID>X("WildMenu", s:green, s:background, "reverse")
 	call <SID>X("VertSplit", s:window, s:window, "none")
 	call <SID>X("Visual", "", s:selection, "")
 	call <SID>X("Directory", s:blue, "", "")


### PR DESCRIPTION
In console vim, the wildmenu selection background color is black, making the text of the selected item difficult to read. Here I've made the text of the selected item white on green.
