### PR TITLE
Changing color of HTML attributes to blue to differentiate from element tags

### DIFF
--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -334,7 +334,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	" HTML Highlighting
 	call <SID>X("htmlTag", s:red, "", "")
 	call <SID>X("htmlTagName", s:red, "", "")
-	call <SID>X("htmlArg", s:red, "", "")
+	call <SID>X("htmlArg", s:blue, "", "")
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting


### PR DESCRIPTION
HTML element tags and attribute names were both red, making HTML a little difficult to parse. Here I've made the attribute names blue so that they stand out more.
