### PR TITLE
Making line numbers more subtle

### DIFF
--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -234,7 +234,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 
 	" Vim Highlighting
 	call <SID>X("Normal", s:foreground, s:background, "")
-  highlight LineNr term=bold cterm=NONE ctermfg=DarkGrey ctermbg=NONE gui=NONE guifg=DarkGrey guibg=NONE
+  highlight LineNr term=bold cterm=NONE ctermfg=LightGray ctermbg=NONE gui=NONE guifg=LightGray guibg=NONE
 	call <SID>X("NonText", s:selection, "", "")
 	call <SID>X("SpecialKey", s:selection, "", "")
 	call <SID>X("Search", s:foreground, s:yellow, "")


### PR DESCRIPTION
The line numbers in dark gray were too distracting, I thought, so I've made them light gray here.
