### PR TITLE
Making search highlighting bright yellow

### DIFF
--- a/colors/Tomorrow.vim
+++ b/colors/Tomorrow.vim
@@ -12,6 +12,7 @@ let s:comment = "8e908c"
 let s:red = "c82829"
 let s:orange = "f5871f"
 let s:yellow = "eab700"
+let s:brightyellow = "ffff00"
 let s:green = "718c00"
 let s:aqua = "3e999f"
 let s:blue = "4271ae"
@@ -237,7 +238,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
   highlight LineNr term=bold cterm=NONE ctermfg=DarkGrey ctermbg=NONE gui=NONE guifg=DarkGrey guibg=NONE
 	call <SID>X("NonText", s:selection, "", "")
 	call <SID>X("SpecialKey", s:selection, "", "")
-	call <SID>X("Search", s:foreground, s:yellow, "")
+	call <SID>X("Search", s:foreground, s:brightyellow, "")
 	call <SID>X("TabLine", s:foreground, s:background, "reverse")
 	call <SID>X("StatusLine", s:window, s:yellow, "reverse")
 	call <SID>X("StatusLineNC", s:window, s:foreground, "reverse")


### PR DESCRIPTION
I wasn't crazy about that "dirty" yellow color used for search highlighting, so I've changed it to a more "highlighter-yellow" here.
